### PR TITLE
Add interval for object freeing

### DIFF
--- a/Sources/XCTAssertNoLeak/Core/Assert.swift
+++ b/Sources/XCTAssertNoLeak/Core/Assert.swift
@@ -18,6 +18,7 @@ func assertNoLeak(_ object: @autoclosure () -> AnyObject, assert: (String, Stati
         node = Node(from: strongObject!)
         strongObject = nil
     }
+    RunLoop.current.run(until: Date(timeIntervalSinceNow: node.intervalForFreeing()))
     node.leakedObjectPaths().forEach { (path) in
         assert(makeAssertMessage(path: path.pathString(with: "self")), file, line)
     }
@@ -42,6 +43,7 @@ func assertNoLeak(_ f: (Context) -> (), assert: @escaping (String, StaticString,
             RunLoop.current.run(until: Date(timeIntervalSinceNow: 0.01))
         }
     }
+    RunLoop.current.run(until: Date(timeIntervalSinceNow: nodes.reduce(TimeInterval(0.0), { $0 + $1.node.intervalForFreeing() })))
     nodes.forEach { element in
         element.node.leakedObjectPaths().forEach { path in
             assert(makeAssertMessage(path: path.pathString(with: element.name)), element.file, element.line)

--- a/Sources/XCTAssertNoLeak/Core/CustomTraversable.swift
+++ b/Sources/XCTAssertNoLeak/Core/CustomTraversable.swift
@@ -15,6 +15,8 @@ public protocol CustomTraversable {
     /// Ignore object assertion if memory leak happen.
     /// Set true if the object is singleton/shared object.
     var ignoreAssertion: Bool { get }
+
+    var intervalForFreeing: TimeInterval { get }
 }
 
 public extension CustomTraversable {
@@ -23,5 +25,8 @@ public extension CustomTraversable {
     }
     var ignoreAssertion: Bool {
         return false
+    }
+    var intervalForFreeing: TimeInterval {
+        return 0.0
     }
 }

--- a/Sources/XCTAssertNoLeak/Core/CustomTraversable.swift
+++ b/Sources/XCTAssertNoLeak/Core/CustomTraversable.swift
@@ -16,6 +16,7 @@ public protocol CustomTraversable {
     /// Set true if the object is singleton/shared object.
     var ignoreAssertion: Bool { get }
 
+    /// Waiting interval for the object freeing.
     var intervalForFreeing: TimeInterval { get }
 }
 

--- a/Sources/XCTAssertNoLeak/Core/Node.swift
+++ b/Sources/XCTAssertNoLeak/Core/Node.swift
@@ -128,4 +128,8 @@ class Node {
             return node.allPaths().map { [path] + $0 }
         }
     }
+
+    func intervalForFreeing() -> TimeInterval {
+        return children.values.reduce((object as? CustomTraversable)?.intervalForFreeing ?? 0.0, { $0 + $1.intervalForFreeing() })
+    }
 }


### PR DESCRIPTION
UITextView is sometime be in memory when all parent object deallocated.
It can solve the problem like that
```swift
extension UITextView: CustomTraversable {
  var intervalForFreeing: TimeInterval { return 1.0 }
}
```