### PR TITLE
Fix for ENABLE_BITCODE compilation issue

### DIFF
--- a/XCTAssertNoLeak.podspec
+++ b/XCTAssertNoLeak.podspec
@@ -17,5 +17,6 @@ Found memory leak objects from traverse object tree using Mirror.
   s.tvos.deployment_target = '9.0'
 
   s.source_files = 'Sources/XCTAssertNoLeak/**/*.{swift}'
-  s.framework = 'XCTest'
+  s.frameworks = "XCTest"
+  s.pod_target_xcconfig = { 'ENABLE_BITCODE' => 'NO' }
 end


### PR DESCRIPTION
```
ld: '/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/Frameworks/XCTest.framework/XCTest' does not contain bitcode. You must rebuild it with bitcode enabled (Xcode setting ENABLE_BITCODE), obtain an updated library from the vendor, or disable bitcode for this target. file '/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/Frameworks/XCTest.framework/XCTest' for architecture arm64
```