### PR TITLE
Add ignoreChildren to CustomTraversable

### DIFF
--- a/Sources/XCTAssertNoLeak/Core/AssertNoLeakContext.swift
+++ b/Sources/XCTAssertNoLeak/Core/AssertNoLeakContext.swift
@@ -27,7 +27,7 @@ public final class AssertNoLeakContext {
         internalContext.elements.append(.init(node: Node(from: object), file: file, line: line))
     }
     
-    @available(*, deprecated, message: "`name` fieald isn't support no longer")
+    @available(*, deprecated, message: "`name` field isn't support no longer")
     public func traverse(name: String, object: AnyObject, file: StaticString=#file, line: UInt=#line) {
         internalContext.elements.append(.init(node: Node(from: object), file: file, line: line))
     }

--- a/Sources/XCTAssertNoLeak/Core/CustomTraversable.swift
+++ b/Sources/XCTAssertNoLeak/Core/CustomTraversable.swift
@@ -14,7 +14,12 @@ public protocol CustomTraversable {
     
     /// Ignore object assertion if memory leak happen.
     /// Set true if the object is singleton/shared object.
+    /// NOTE: The children will be checked if the assertion has ignored. To ignore children too, use with ignoreChildren.
     var ignoreAssertion: Bool { get }
+
+    /// Ignore all children and doesn't check their leak.
+    /// customTraverseKeyPaths will be ignored if this set true.
+    var ignoreChildren: Bool { get }
 
     /// Waiting interval for the object freeing.
     var intervalForFreeing: TimeInterval { get }
@@ -25,6 +30,9 @@ public extension CustomTraversable {
         return []
     }
     var ignoreAssertion: Bool {
+        return false
+    }
+    var ignoreChildren: Bool {
         return false
     }
     var intervalForFreeing: TimeInterval {

--- a/Sources/XCTAssertNoLeak/Core/Node.swift
+++ b/Sources/XCTAssertNoLeak/Core/Node.swift
@@ -78,14 +78,16 @@ class Node {
                 self.object = nil
             }
         }
-        let mirror = Mirror(reflecting: object)
-        if let object = object as? OptionalKind {
+        if let customTraversable = (object as? CustomTraversable), customTraversable.ignoreChildren {
+            children = [:]
+        } else if let object = object as? OptionalKind {
             if let value = object.optional, let node = Node(from: value, discoveredObject: &discoveredObject) {
                 children = [Path.optional: node]
             } else {
                 children = [:]
             }
         } else {
+            let mirror = Mirror(reflecting: object)
             let childNodesFromMirror = mirror.children
                 .enumerated()
                 .compactMap { (index, mirrorChild) in

--- a/Tests/XCTAssertNoLeakTests/NodeTests.swift
+++ b/Tests/XCTAssertNoLeakTests/NodeTests.swift
@@ -99,10 +99,26 @@ final class NodeTests: XCTestCase {
         )
     }
     #endif
+
+    func testIgnoreChildren() {
+        class Foo: CustomTraversable {
+            var value = 1
+            let ignoreChildren = true
+        }
+
+        let node = Node(from: Foo())
+        XCTAssertEqual(
+            node.allPaths(),
+            [
+                [],
+            ]
+        )
+    }
     
     static var allTests = [
         ("testGetReferenceValue", testGetReferenceValue),
         ("testOptionalPath", testOptionalPath),
         ("testLazyPropertyPath", testLazyPropertyPath),
+        ("testIgnoreChildren", testIgnoreChildren),
     ]
 }


### PR DESCRIPTION
#11

Add `ignoreChildren` property. Stop to make child nodes when `ignoreChildren` was true.