### PR TITLE
Bump up support versions on Package.swift

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -6,8 +6,8 @@ import PackageDescription
 let package = Package(
     name: "XCTAssertNoLeak",
     platforms: [
-        .iOS(.v8),
-        .macOS(.v10_10),
+        .iOS(.v9),
+        .macOS(.v10_11),
         .tvOS(.v9),
         .watchOS(.v2)
     ],


### PR DESCRIPTION
closes #16 

[Warning with Xcode 13 when using with Swift Package Manager · Issue #16 · tarunon/XCTAssertNoLeak](https://github.com/tarunon/XCTAssertNoLeak/issues/16)

I faced the same problem. (He is my co-worker 😄 )

Currently, the latest Xcode raises warnings to upgrade the lowest target SDK versions.

According to the [podspec](https://github.com/tarunon/XCTAssertNoLeak/blob/master/XCTAssertNoLeak.podspec), supported platforms are miss-matched between `Package.swift`.

So I fixed supported platform versions on `Package.swift`. These changes will suppress that warnings.